### PR TITLE
Remove duration column from listings table

### DIFF
--- a/CityDBMigrations/Migrations/20250625133218_AlterListingsDurationColumTable.cs
+++ b/CityDBMigrations/Migrations/20250625133218_AlterListingsDurationColumTable.cs
@@ -1,0 +1,27 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20250625133218)]
+    public class AlterListingsDurationColumTable : Migration
+    {
+        public override void Up()
+        {
+            string sql =
+               @"
+                 ALTER TABLE listings drop column duration;
+                ";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            string sql =
+               @"ALTER TABLE listings add column duration varchar(20) CHECK (duration REGEXP '^[0-9]+[dhm]([0-9]+[dhm])*$');
+                ";
+            // not changing back to varchar(1000) because it's not guaranteed that the message will fit in 1000 characters after encryption.
+            Execute.Sql(sql);
+        }
+    }
+}

--- a/CityDBMigrations/Migrations/20250909130400_AddCityAdminRole.cs
+++ b/CityDBMigrations/Migrations/20250909130400_AddCityAdminRole.cs
@@ -1,0 +1,23 @@
+using FluentMigrator;
+
+namespace DatabaseMigrations.Migrations
+{
+    [Migration(20250909130400)]
+    public class AddCityAdminRole : Migration
+    {
+        public override void Up()
+        {
+            string sql = @"
+                INSERT INTO roles
+                (id, name)
+                VALUES(4, 'City Admin');";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DELETE FROM roles WHERE id = 4;");
+        }
+    }
+}

--- a/CoreDBMigrations/Migrations/20250908163420_CreateUserOnBoardedTable.cs
+++ b/CoreDBMigrations/Migrations/20250908163420_CreateUserOnBoardedTable.cs
@@ -1,0 +1,33 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20250908163420)]
+    public class CreateUserOnBoardedTable : Migration
+    {
+        public override void Up()
+        {
+            string sql = @"
+                CREATE TABLE IF NOT EXISTS users_onboarded (
+                  `id` int NOT NULL AUTO_INCREMENT,
+                  `email` varchar(255) NOT NULL,
+                  `roleId` int NOT NULL,
+                  `createdAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+                  `updatedAt` timestamp NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                  `onBoarded` tinyint(1) DEFAULT '0',
+                  `cities` json DEFAULT NULL,
+                  PRIMARY KEY (`id`),
+                  UNIQUE KEY `UC_Email` (`email`),
+                  KEY `FK_RoleIdOnboard` (`roleId`),
+                  CONSTRAINT `FK_RoleIdOnboard` FOREIGN KEY (`roleId`) REFERENCES `roles` (`id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DROP TABLE IF EXISTS users_onboarded;");
+        }
+    }
+}

--- a/CoreDBMigrations/Migrations/20250909130400_AddCityAdminRole.cs
+++ b/CoreDBMigrations/Migrations/20250909130400_AddCityAdminRole.cs
@@ -1,0 +1,23 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20250909130400)]
+    public class AddCityAdminRole : Migration
+    {
+        public override void Up()
+        {
+            string sql = @"
+                INSERT INTO roles
+                (id, name)
+                VALUES(4, 'City Admin');";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DELETE FROM roles WHERE id = 4;");
+        }
+    }
+}

--- a/CoreDBMigrations/Migrations/20250909132900_CreateCityUserRoleTable.cs
+++ b/CoreDBMigrations/Migrations/20250909132900_CreateCityUserRoleTable.cs
@@ -1,0 +1,29 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20250909132900)]
+    public class CreateCityUserRoleTable : Migration
+    {
+        public override void Up()
+        {
+            string sql = @"
+                CREATE TABLE `city_user_roles` (
+                `cityId` int NOT NULL,
+                `userId` int NOT NULL,
+                `isAdmin` tinyint(1) DEFAULT '0',
+                KEY `FK_CityUserRoles_City` (`cityId`),
+                KEY `FK_CityUserRoles_User` (`userId`),
+                CONSTRAINT `FK_CityUserRoles_City` FOREIGN KEY (`cityId`) REFERENCES `cities` (`id`),
+                CONSTRAINT `FK_CityUserRoles_User` FOREIGN KEY (`userId`) REFERENCES `users` (`id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DROP TABLE IF EXISTS city_user_roles;");
+        }
+    }
+}


### PR DESCRIPTION
Eliminate the duration column from the listings table to streamline the database schema. This change includes migration scripts for both applying and reverting the modification.