### PR TITLE
feat: Add forum_event_images table migration

### DIFF
--- a/CoreDBMigrations/Migrations/20250627124754_AddForumEventImagesTable.cs
+++ b/CoreDBMigrations/Migrations/20250627124754_AddForumEventImagesTable.cs
@@ -1,0 +1,37 @@
+using FluentMigrator;
+
+namespace DatabaseMigrations.Migrations
+{
+    [Migration(20250627124754)]
+    public class AddForumEventImagesTable : Migration
+    {
+        public override void Up()
+        {
+            string sql =
+                            @"CREATE TABLE IF NOT EXISTS `forum_event_images` (
+                `id` int NOT NULL AUTO_INCREMENT,
+                `eventId` int NOT NULL,
+                `imagePath` varchar(1000) NOT NULL,
+                `originalName` varchar(255) DEFAULT NULL,
+                `fileSize` int DEFAULT NULL,
+                `mimeType` varchar(100) DEFAULT NULL,
+                `imageOrder` int DEFAULT NULL,
+                `createdAt` datetime DEFAULT CURRENT_TIMESTAMP,
+                `updatedAt` datetime DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (`id`),
+                KEY `eventId` (`eventId`),
+                KEY `imageOrder` (`imageOrder`),
+                CONSTRAINT `forum_event_images_ibfk_1` FOREIGN KEY (`eventId`) REFERENCES `forum_events` (`id`) ON DELETE CASCADE
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;";
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            string sql =
+               @"DROP TABLE IF EXISTS `forum_event_images`";
+
+            Execute.Sql(sql);
+        }
+    }
+}


### PR DESCRIPTION
- Created migration 20250627124754_AddForumEventImagesTable.cs
- Added forum_event_images table with columns: id, eventId, imagePath, originalName, fileSize, mimeType, imageOrder, createdAt, updatedAt
- Added imageOrder columns
- Added foreign key constraint referencing forum_events table with CASCADE delete
