### PR TITLE
Add ON DELETE CASCADE to forum_user_keys userKeyId foreign key

### DIFF
--- a/CoreDBMigrations/Migrations/20250707000000_UpdateForumUserKeysUserKeyForeignKey.cs
+++ b/CoreDBMigrations/Migrations/20250707000000_UpdateForumUserKeysUserKeyForeignKey.cs
@@ -1,0 +1,28 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20250707000000)]
+    public class UpdateForumUserKeysUserKeyForeignKey : Migration
+    {
+        public override void Up()
+        {
+            string sql =
+               @"ALTER TABLE forum_user_keys DROP FOREIGN KEY forum_user_keys_ibfk_2;
+                 ALTER TABLE forum_user_keys ADD CONSTRAINT forum_user_keys_ibfk_2 
+                 FOREIGN KEY (userKeyId) REFERENCES user_keys(id) ON DELETE CASCADE;";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            string sql =
+               @"ALTER TABLE forum_user_keys DROP FOREIGN KEY forum_user_keys_ibfk_2;
+                 ALTER TABLE forum_user_keys ADD CONSTRAINT forum_user_keys_ibfk_2 
+                 FOREIGN KEY (userKeyId) REFERENCES user_keys(id);";
+
+            Execute.Sql(sql);
+        }
+    }
+}


### PR DESCRIPTION
- Updates the foreign key constraint for userKeyId in forum_user_keys table
- Adds ON DELETE CASCADE to automatically delete forum_user_keys records when related user_keys are deleted
- Includes rollback functionality in the Down migration method