### PR TITLE
Add migration scripts for Mullkalender database tables

### DIFF
--- a/CoreDBMigrations/Migrations/20260203100000_AddMullkalenderPushDevicesTable.cs
+++ b/CoreDBMigrations/Migrations/20260203100000_AddMullkalenderPushDevicesTable.cs
@@ -1,0 +1,34 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20260203100000)]
+    public class AddMullkalenderPushDevicesTable : Migration
+    {
+        public override void Up()
+        {
+            string sql =
+                @"CREATE TABLE IF NOT EXISTS mullkalender_push_devices (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    device_id VARCHAR(255) NOT NULL,
+                    fcm_token VARCHAR(255) NOT NULL,
+                    device_type VARCHAR(50) NOT NULL DEFAULT 'android',
+                    app_version VARCHAR(20) NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    is_active BOOLEAN DEFAULT TRUE,
+                    
+                    UNIQUE KEY unique_device_id (device_id),
+                    UNIQUE KEY unique_fcm_token (fcm_token),
+                    INDEX idx_is_active (is_active)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DROP TABLE IF EXISTS mullkalender_push_devices;");
+        }
+    }
+}

--- a/CoreDBMigrations/Migrations/20260203100001_AddMullkalenderPushDeviceStreetsTable.cs
+++ b/CoreDBMigrations/Migrations/20260203100001_AddMullkalenderPushDeviceStreetsTable.cs
@@ -1,0 +1,34 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20260203100001)]
+    public class AddMullkalenderPushDeviceStreetsTable : Migration
+    {
+        public override void Up()
+        {
+            string sql =
+                @"CREATE TABLE IF NOT EXISTS mullkalender_push_device_streets (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    push_device_id INT NOT NULL COMMENT 'References mullkalender_push_devices.id',
+                    city_id INT NOT NULL,
+                    street_id INT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                    is_active BOOLEAN DEFAULT TRUE,
+                    
+                    FOREIGN KEY (push_device_id) REFERENCES mullkalender_push_devices(id) ON DELETE CASCADE,
+                    UNIQUE KEY unique_device (push_device_id),
+                    INDEX idx_city_street (city_id, street_id),
+                    INDEX idx_is_active (is_active)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DROP TABLE IF EXISTS mullkalender_push_device_streets;");
+        }
+    }
+}

--- a/CoreDBMigrations/Migrations/20260203100002_AddMullkalenderPushDeviceWasteTypesTable.cs
+++ b/CoreDBMigrations/Migrations/20260203100002_AddMullkalenderPushDeviceWasteTypesTable.cs
@@ -1,0 +1,30 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20260203100002)]
+    public class AddMullkalenderPushDeviceWasteTypesTable : Migration
+    {
+        public override void Up()
+        {
+            string sql =
+                @"CREATE TABLE IF NOT EXISTS mullkalender_push_device_waste_types (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    device_street_id INT NOT NULL,
+                    waste_type_id INT NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    
+                    FOREIGN KEY (device_street_id) REFERENCES mullkalender_push_device_streets(id) ON DELETE CASCADE,
+                    UNIQUE KEY unique_device_street_waste (device_street_id, waste_type_id),
+                    INDEX idx_waste_type (waste_type_id)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DROP TABLE IF EXISTS mullkalender_push_device_waste_types;");
+        }
+    }
+}

--- a/CoreDBMigrations/Migrations/20260203100003_AddMullkalenderNotificationLogTable.cs
+++ b/CoreDBMigrations/Migrations/20260203100003_AddMullkalenderNotificationLogTable.cs
@@ -1,0 +1,41 @@
+using FluentMigrator;
+
+namespace CoreDBMigrations.Migrations
+{
+    [Migration(20260203100003)]
+    public class AddMullkalenderNotificationLogTable : Migration
+    {
+        public override void Up()
+        {
+            string sql =
+                @"CREATE TABLE IF NOT EXISTS mullkalender_notification_log (
+                    id INT PRIMARY KEY AUTO_INCREMENT,
+                    push_device_id INT NOT NULL COMMENT 'References mullkalender_push_devices.id',
+                    city_id INT NOT NULL,
+                    street_id INT NOT NULL,
+                    pickup_date DATE NOT NULL,
+                    waste_type_ids VARCHAR(100) NOT NULL COMMENT 'Comma-separated waste type IDs that were notified',
+                    notification_body TEXT NULL COMMENT 'The notification message sent',
+                    status ENUM('pending', 'sent', 'failed', 'skipped') DEFAULT 'pending',
+                    retry_count INT DEFAULT 0,
+                    error_message VARCHAR(500) NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    sent_at TIMESTAMP NULL,
+                    
+                    FOREIGN KEY (push_device_id) REFERENCES mullkalender_push_devices(id) ON DELETE CASCADE,
+                    UNIQUE KEY unique_device_street_date (push_device_id, city_id, street_id, pickup_date),
+                    INDEX idx_pickup_date (pickup_date),
+                    INDEX idx_status (status),
+                    INDEX idx_device (push_device_id),
+                    INDEX idx_city_street_date (city_id, street_id, pickup_date)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+
+            Execute.Sql(sql);
+        }
+
+        public override void Down()
+        {
+            Execute.Sql("DROP TABLE IF EXISTS mullkalender_notification_log;");
+        }
+    }
+}


### PR DESCRIPTION
- Created `mullkalender_push_devices` table to store device information.
- Created `mullkalender_push_device_streets` table to link devices with streets.
- Created `mullkalender_push_device_waste_types` table to associate waste types with device streets.
- Created `mullkalender_notification_log` table to log notifications sent to devices.